### PR TITLE
Remove deprecated hass argument from async_extract_config_entry_ids

### DIFF
--- a/custom_components/ssh/__init__.py
+++ b/custom_components/ssh/__init__.py
@@ -307,7 +307,7 @@ def async_register_services(hass: HomeAssistant, domain: str):
     def get_response(coro: Coroutine):
         @wraps(coro)
         async def wrapper(call: ServiceCall) -> ServiceResponse | None:
-            entry_ids = await async_extract_config_entry_ids(hass, call)
+            entry_ids = await async_extract_config_entry_ids(call)
             data = await asyncio.gather(
                 *(coro(hass.data[domain][entry_id], call) for entry_id in entry_ids)
             )


### PR DESCRIPTION
Fixes this warning:
"The deprecated argument hass was passed to async_extract_config_entry_ids from ssh. It will be removed in HA Core 2026.10"

Changed from:
entry_ids = await async_extract_config_entry_ids(hass, call)

To:
entry_ids = await async_extract_config_entry_ids(call)

Tested and working in local environment.
